### PR TITLE
Fix AlfWorld teacher skill retrieval to load task-specific skills

### DIFF
--- a/agent_system/multi_turn_rollout/rollout_loop.py
+++ b/agent_system/multi_turn_rollout/rollout_loop.py
@@ -26,6 +26,12 @@ from agent_system.environments import EnvironmentManagerBase
 from typing import List, Dict
 from verl.protocol import pad_dataproto_to_divisor, unpad_dataproto
 
+
+def _gamefiles_from_infos(infos: List[Dict]) -> np.ndarray:
+    """Extract per-env AlfWorld gamefile paths from env step/reset infos."""
+    return np.array([info.get("extra.gamefile") for info in infos], dtype=object)
+
+
 class TrajectoryCollector:
     def __init__(self, config, tokenizer: PreTrainedTokenizer, processor=None):
         """
@@ -67,6 +73,7 @@ class TrajectoryCollector:
         obs_texts = obs.get('text', None)
         obs_images = obs.get('image', None)
         obs_anchors = obs.get('anchor', None)
+        obs_gamefiles = obs.get('gamefile', None)
         obs_text = obs_texts[item] if obs_texts is not None else None
         obs_image = obs_images[item] if obs_images is not None else None
         obs_anchor = obs_anchors[item] if obs_anchors is not None else None
@@ -181,6 +188,12 @@ class TrajectoryCollector:
             'index': item,
             'data_source': data_source
         })
+
+        # AlfWorld SDAR/RLSD: pass gamefile so teacher can inject task-specific skills.
+        if obs_gamefiles is not None:
+            gamefile = obs_gamefiles[item]
+            if gamefile is not None:
+                row_dict['gamefile'] = gamefile if isinstance(gamefile, str) else str(gamefile)
 
         if self.config.data.get('return_raw_chat', False):
             row_dict['raw_prompt'] = chat.tolist()
@@ -309,6 +322,7 @@ class TrajectoryCollector:
 
         # Initial observations from the environment
         obs, infos = envs.reset(kwargs=gen_batch.non_tensor_batch.pop('env_kwargs', None))
+        current_gamefiles = _gamefiles_from_infos(infos)
 
         lenght_obs = len(obs['text']) if obs['text'] is not None else len(obs['image'])
         assert len(gen_batch.batch) == lenght_obs, f"gen_batch size {len(gen_batch.batch)} does not match obs size {lenght_obs}"
@@ -334,7 +348,10 @@ class TrajectoryCollector:
         for _step in range(self.config.env.max_steps):
             active_masks = np.logical_not(is_done)
 
-            batch = self.preprocess_batch(gen_batch=gen_batch, obs=obs)
+            obs_input = obs
+            if current_gamefiles is not None:
+                obs_input = {**obs, 'gamefile': current_gamefiles}
+            batch = self.preprocess_batch(gen_batch=gen_batch, obs=obs_input)
 
             batch_keys_to_pop = ["input_ids", "attention_mask", "position_ids"]
             non_tensor_batch_keys_to_pop = ["raw_prompt_ids"]
@@ -365,8 +382,8 @@ class TrajectoryCollector:
             text_actions = self.tokenizer.batch_decode(batch.batch['responses'], skip_special_tokens=True)
             
             next_obs, rewards, dones, infos = envs.step(text_actions)
+            current_gamefiles = _gamefiles_from_infos(infos)
 
-            
             if len(rewards.shape) == 2:
                 rewards = rewards.squeeze(1)
             if len(dones.shape) == 2:

--- a/verl/trainer/ppo/rlsd_ray_trainer.py
+++ b/verl/trainer/ppo/rlsd_ray_trainer.py
@@ -92,8 +92,15 @@ def build_teacher_batch(
         gamefile = batch.non_tensor_batch.get("gamefile", None)
         data_source = batch.non_tensor_batch.get("data_source", None)
         if gamefile is not None:
-            gf = gamefile[i] if isinstance(gamefile[i], str) else str(gamefile[i])
-            skill_text = skill_provider.get_privileged_info(gf)
+            gf = gamefile[i]
+            if gf is not None:
+                gf = gf if isinstance(gf, str) else str(gf)
+                skill_text = skill_provider.get_privileged_info(gf)
+            elif data_source is not None:
+                ds = data_source[i] if isinstance(data_source[i], str) else str(data_source[i])
+                skill_text = skill_provider.get_privileged_info_from_data_source(ds, prompt_text)
+            else:
+                skill_text = skill_provider.get_privileged_info_from_prompt(prompt_text)
         elif data_source is not None:
             ds = data_source[i] if isinstance(data_source[i], str) else str(data_source[i])
             skill_text = skill_provider.get_privileged_info_from_data_source(ds, prompt_text)

--- a/verl/trainer/ppo/rlsd_utils.py
+++ b/verl/trainer/ppo/rlsd_utils.py
@@ -117,6 +117,7 @@ class SkillProvider:
           - data_source in ('nq', 'triviaqa') -> direct_retrieval
           - prompt contains 'which' + 'or' (without 'for') -> compare
           - data_source == 'hotpotqa' -> multi_hop_reasoning
+          - data_source == 'text' (AlfWorld/Webshop parquet) -> prompt keyword matching
           - otherwise -> general skills only (unknown)
         """
         if self.skill_all:
@@ -136,6 +137,8 @@ class SkillProvider:
             elif data_source in ("2wikimultihopqa", "musique", "bamboogle"):
                 task_type = "multi_hop_reasoning"
 
+        if task_type is None and data_source == "text":
+            return self.get_privileged_info_from_prompt(prompt_text)
         return self._get_skill_text(task_type)
 
 


### PR DESCRIPTION
## Summary
- Propagate AlfWorld `extra.gamefile` from rollout into the training batch so the teacher can match heat/cool/clean skills by task type.
- Fallback to prompt keyword matching when `data_source` is `text` (AlfWorld/Webshop parquet).
- Skip `None` gamefile entries instead of treating them as the literal string `"None"`.

Previously, AlfWorld SDAR/RLSD/SkillSD teacher distillation only injected `general_skills` because rollout never passed `gamefile` into the batch, and `get_privileged_info_from_data_source("text", ...)` had no AlfWorld-specific fallback.

## Test plan
- [ ] Run AlfWorld SDAR/RLSD training and verify teacher privileged text includes task-specific skills (e.g. heat task contains microwave-related content).
- [ ] Confirm Search-QA datasets still use `data_source`-based skill routing unchanged.
- [ ] Confirm other environments without `extra.gamefile` behave as before.

Made with [Cursor](https://cursor.com)